### PR TITLE
Full Port of Slope to C++ with CMake.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.vscode
+*.out
+.DS_Store
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+slope

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(slope slope.cc)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # slopeCPP
-A port of my Slope program to C++
+A port of my [Slope](https://github.com/Kitty-Cats/slope) program to C++
+
+
+To build: `cmake && make`

--- a/slope.cc
+++ b/slope.cc
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <string>
+
+const std::string defaultUnit = "*";
+void slope(int size, std::string unit){
+    int row;
+    int width;
+    for(row=0;row<size;row++){
+        for(width=-1;width<row;width++){        
+            std::cout << unit;
+        }
+        std::cout << std::endl;
+    }
+}
+int main(){
+    std::string unit,size;
+    std::cout << "Enter a character to use:" << std::endl;
+    std::cin >> unit;
+    std::cout << "Choose the size of the slope:" << std::endl;
+    std::cin >> size;
+    std::cout << std::endl;
+    int sizeInt = std::stoi(size);
+    slope(sizeInt,unit);
+}


### PR DESCRIPTION
* Change `char*` to `std::string`
* Change `printf` to `std::cout`
* Take arguments with `std::cin` instead of `argv`
* Added CMake